### PR TITLE
Removed python bindings for nano GUI for simplicity.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@
 *.exe
 *.out
 *.app
+
+# Build
+build
+external

--- a/cmake/UseNanoGUI.cmake
+++ b/cmake/UseNanoGUI.cmake
@@ -56,6 +56,7 @@ macro(UseNanoGUI YOUR_TARGET INTERFACE_PUBLIC_OR_PRIVATE DOWNLOAD_DIR)
             NanoGUI
             ${DOWNLOAD_DIR}
             src
+            -DNANOGUI_BUILD_PYTHON=OFF
         )
 
 


### PR DESCRIPTION
This pull request has two suggestions:

1. Add build and external to .gitignore.
2. I removed the NanoGUI python bindings requirement as it would require installing another library on their machine (python-dev).  I imagine we won't be using the python bindings for our purposes of the class, but I could be wrong.  It seems easier to remove the dependency, and perhaps if someone wanted to enable it they could.

Thanks,
Dan