### PR TITLE
Enabled the option to init graphics outside the constructor.

### DIFF
--- a/example/CircleViewer.cpp
+++ b/example/CircleViewer.cpp
@@ -15,7 +15,7 @@ CircleViewer::~CircleViewer() {
     
 }
 
-void CircleViewer::InitGraphics() {
+void CircleViewer::InitNanoGUI() {
     nanogui::FormHelper *gui = new nanogui::FormHelper(screen());
     nanogui::ref<nanogui::Window> window = gui->addWindow(Eigen::Vector2i(10, 10), "Simulation Controls");    
     pauseBtn_ = gui->addButton("Pause", std::bind(&CircleViewer::OnPauseBtnPressed, this));

--- a/example/CircleViewer.cpp
+++ b/example/CircleViewer.cpp
@@ -5,14 +5,7 @@
 #include <iostream>
 
 
-CircleViewer::CircleViewer() : GraphicsApp(1024,768, "Circle Simulation") {
-    nanogui::FormHelper *gui = new nanogui::FormHelper(screen());
-    nanogui::ref<nanogui::Window> window = gui->addWindow(Eigen::Vector2i(10, 10), "Simulation Controls");    
-    pauseBtn_ = gui->addButton("Pause", std::bind(&CircleViewer::OnPauseBtnPressed, this));
-    gui->addButton("Restart", std::bind(&CircleViewer::OnRestartBtnPressed, this));
-
-    screen()->performLayout();
-
+CircleViewer::CircleViewer() : GraphicsApp(1024,768, "Circle Simulation",false) {
     simTime_ = 0.0;
     paused_ = false;
 }
@@ -22,6 +15,14 @@ CircleViewer::~CircleViewer() {
     
 }
 
+void CircleViewer::InitGraphics() {
+    nanogui::FormHelper *gui = new nanogui::FormHelper(screen());
+    nanogui::ref<nanogui::Window> window = gui->addWindow(Eigen::Vector2i(10, 10), "Simulation Controls");    
+    pauseBtn_ = gui->addButton("Pause", std::bind(&CircleViewer::OnPauseBtnPressed, this));
+    gui->addButton("Restart", std::bind(&CircleViewer::OnRestartBtnPressed, this));
+
+    screen()->performLayout();
+}
 
 void CircleViewer::UpdateSimulation(double dt) {
     if (!paused_) {

--- a/example/CircleViewer.h
+++ b/example/CircleViewer.h
@@ -36,7 +36,7 @@ public:
     CircleViewer();
     ~CircleViewer();
 
-    void InitGraphics();
+    void InitNanoGUI();
 
     void UpdateSimulation(double dt);
 

--- a/example/CircleViewer.h
+++ b/example/CircleViewer.h
@@ -36,6 +36,8 @@ public:
     CircleViewer();
     ~CircleViewer();
 
+    void InitGraphics();
+
     void UpdateSimulation(double dt);
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -83,10 +83,10 @@ UseNanoGUI(MinGfx PUBLIC ${EXTERNAL_DIR})
 include(UseOpenGL)
 UseOpenGL(MinGfx PUBLIC ${EXTERNAL_DIR})
 
-option(INIT_GFX_NO_CONSTRUCTOR "Forces graphics applications to use the InitGraphics() for initializing graphics instead of the constructor." OFF)
+option(ALLOW_INIT_GFX_CTX_IN_CONSTRUCTOR "Allows graphics contexts to initialize in the application constructor." ON)
 
-if(INIT_GFX_NO_CONSTRUCTOR)
-    target_compile_definitions(MinGfx PUBLIC -DINIT_GFX_NO_CONSTRUCTOR)
+if(ALLOW_INIT_GFX_CTX_IN_CONSTRUCTOR)
+    target_compile_definitions(MinGfx PUBLIC -DALLOW_INIT_GFX_CTX_IN_CONSTRUCTOR)
 endif()
 
 install(TARGETS MinGfx EXPORT MinGfxTargets COMPONENT CoreLib

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -83,6 +83,11 @@ UseNanoGUI(MinGfx PUBLIC ${EXTERNAL_DIR})
 include(UseOpenGL)
 UseOpenGL(MinGfx PUBLIC ${EXTERNAL_DIR})
 
+option(INIT_GFX_NO_CONSTRUCTOR "Forces graphics applications to use the InitGraphics() for initializing graphics instead of the constructor." OFF)
+
+if(INIT_GFX_NO_CONSTRUCTOR)
+    target_compile_definitions(MinGfx PUBLIC -DINIT_GFX_NO_CONSTRUCTOR)
+endif()
 
 install(TARGETS MinGfx EXPORT MinGfxTargets COMPONENT CoreLib
   LIBRARY DESTINATION ${INSTALL_LIB_DEST}

--- a/src/graphics_app.cc
+++ b/src/graphics_app.cc
@@ -11,21 +11,21 @@ namespace mingfx {
 
 
 
-GraphicsApp::GraphicsApp(int width, int height, const std::string &caption, bool initGraphicsInConstructor) : lastDrawT_(0.0), width_(width), height_(height), caption_(caption), initGraphicsInConstructor_(initGraphicsInConstructor) {
+GraphicsApp::GraphicsApp(int width, int height, const std::string &caption, bool initGraphicsContextInConstructor) : lastDrawT_(0.0), width_(width), height_(height), caption_(caption), initGraphicsContextInConstructor_(initGraphicsContextInConstructor) {
 // Adding temporary solution for forcing the use of InitGraphics() method for automated testing without graphics.
-#ifdef INIT_GFX_NO_CONSTRUCTOR
-    initGraphicsInConstructor_ = false;
+#ifndef ALLOW_INIT_GFX_CTX_IN_CONSTRUCTOR
+    initGraphicsContextInConstructor_ = false;
 #endif
 
-    if (initGraphicsInConstructor_) {
-        initWindow(); 
+    if (initGraphicsContextInConstructor_) {
+        initGraphicsContext(); 
     }
 }
 
 GraphicsApp::~GraphicsApp() {
 }
 
-void GraphicsApp::initWindow() {
+void GraphicsApp::initGraphicsContext() {
     
     glfwInit();
     
@@ -131,11 +131,11 @@ void GraphicsApp::initWindow() {
     
 void GraphicsApp::Run() {
 
-    if(!initGraphicsInConstructor_) {
-        initWindow();        
+    if(!initGraphicsContextInConstructor_) {
+        initGraphicsContext();        
     }
 
-    InitGraphics();
+    InitNanoGUI();
 
     InitOpenGL();
     

--- a/src/graphics_app.cc
+++ b/src/graphics_app.cc
@@ -11,7 +11,21 @@ namespace mingfx {
 
 
 
-GraphicsApp::GraphicsApp(int width, int height, const std::string &caption) : lastDrawT_(0.0) {
+GraphicsApp::GraphicsApp(int width, int height, const std::string &caption, bool initGraphicsInConstructor) : lastDrawT_(0.0), width_(width), height_(height), caption_(caption), initGraphicsInConstructor_(initGraphicsInConstructor) {
+// Adding temporary solution for forcing the use of InitGraphics() method for automated testing without graphics.
+#ifdef INIT_GFX_NO_CONSTRUCTOR
+    initGraphicsInConstructor_ = false;
+#endif
+
+    if (initGraphicsInConstructor_) {
+        initWindow(); 
+    }
+}
+
+GraphicsApp::~GraphicsApp() {
+}
+
+void GraphicsApp::initWindow() {
     
     glfwInit();
     
@@ -32,7 +46,7 @@ GraphicsApp::GraphicsApp(int width, int height, const std::string &caption) : la
     glfwWindowHint(GLFW_RESIZABLE, GL_TRUE);
     
     // Create a GLFWwindow object
-    window_ = glfwCreateWindow(width, height, caption.c_str(), nullptr, nullptr);
+    window_ = glfwCreateWindow(width_, height_, caption_.c_str(), nullptr, nullptr);
     if (window_ == nullptr) {
         std::cerr << "Failed to create GLFW window" << std::endl;
         glfwTerminate();
@@ -55,8 +69,8 @@ GraphicsApp::GraphicsApp(int width, int height, const std::string &caption) : la
     screen_ = new nanogui::Screen();
     screen_->initialize(window_, true);
     
-    glfwGetFramebufferSize(window_, &width, &height);
-    glViewport(0, 0, width, height);
+    glfwGetFramebufferSize(window_, &width_, &height_);
+    glViewport(0, 0, width_, height_);
     glfwSwapInterval(0);
     glfwSwapBuffers(window_);
     
@@ -113,13 +127,16 @@ GraphicsApp::GraphicsApp(int width, int height, const std::string &caption) : la
     );
  }
 
-GraphicsApp::~GraphicsApp() {
-}
-
 
     
 void GraphicsApp::Run() {
-    
+
+    if(!initGraphicsInConstructor_) {
+        initWindow();        
+    }
+
+    InitGraphics();
+
     InitOpenGL();
     
     // Main program loop

--- a/src/graphics_app.h
+++ b/src/graphics_app.h
@@ -124,7 +124,7 @@ public:
      \param height The height of the client area of the window in pixels.
      \param caption The caption for the window's title bar.
      */
-    GraphicsApp(int width, int height, const std::string &caption);
+    GraphicsApp(int width, int height, const std::string &caption, bool initGraphicsInConstructor = true);
 
 
     /// The destructor will shutdown the graphics system and window
@@ -233,6 +233,11 @@ public:
      */
     void Run();
     
+    /** Called at the beginning of the Run() method.  This will initialize
+      any graphics window related properties including 2D windows, buttons,
+      sliders, etc...
+     */
+    virtual void InitGraphics() {}
     
     /** Called once per frame.  Override this and fill it in to update your 
      simulation code or any other updates you need to make to your model that 
@@ -331,6 +336,7 @@ public:
 
 private:
     
+    void initWindow();
     bool cursor_pos_glfw_cb(double x, double y);
     bool mouse_button_glfw_cb(int button, int action, int modifiers);
     bool key_glfw_cb(int key, int scancode, int action, int mods);
@@ -339,6 +345,10 @@ private:
     bool scroll_glfw_cb(double x, double y);
     bool resize_glfw_cb(int width, int height);
     
+    bool initGraphicsInConstructor_;
+    int width_;
+    int height_;
+    const std::string &caption_;
     nanogui::Screen *screen_;
     GLFWwindow* window_;
     double lastDrawT_;

--- a/src/graphics_app.h
+++ b/src/graphics_app.h
@@ -72,6 +72,11 @@ namespace mingfx {
  class MyApp : public GraphcisApp {
  public:
     MyApp() : GraphicsApp(1024,768, "My Amazing App") {
+    }
+    
+    virtual ~MyApp() {}
+
+    void InitNanoGUI() {
         // Setup the GUI window
         nanogui::Window *window = new nanogui::Window(screen(), "My GUI Panel");
         window->setPosition(Eigen::Vector2i(10, 10));
@@ -84,8 +89,6 @@ namespace mingfx {
  
         screen()->performLayout();
     }
-    
-    virtual ~MyApp() {}
  
     void OnMouseMove(const Point2 &pos, const Vector2 &delta) {
         std::cout << "Mouse moved to " << pos << std::endl;
@@ -234,10 +237,10 @@ public:
     void Run();
     
     /** Called at the beginning of the Run() method.  This will initialize
-      any graphics window related properties including 2D windows, buttons,
+      any NanoGUI graphics related properties including 2D windows, buttons,
       sliders, etc...
      */
-    virtual void InitGraphics() {}
+    virtual void InitNanoGUI() {}
     
     /** Called once per frame.  Override this and fill it in to update your 
      simulation code or any other updates you need to make to your model that 
@@ -336,7 +339,7 @@ public:
 
 private:
     
-    void initWindow();
+    void initGraphicsContext();
     bool cursor_pos_glfw_cb(double x, double y);
     bool mouse_button_glfw_cb(int button, int action, int modifiers);
     bool key_glfw_cb(int key, int scancode, int action, int mods);
@@ -345,7 +348,7 @@ private:
     bool scroll_glfw_cb(double x, double y);
     bool resize_glfw_cb(int width, int height);
     
-    bool initGraphicsInConstructor_;
+    bool initGraphicsContextInConstructor_;
     int width_;
     int height_;
     const std::string &caption_;

--- a/src/graphics_app.h
+++ b/src/graphics_app.h
@@ -269,37 +269,37 @@ public:
     
     /// True if the specified is is currently held down.  Uses the GLFW
     /// key codes found here: http://www.glfw.org/docs/latest/group__keys.html
-    bool IsKeyDown(int key);
+    virtual bool IsKeyDown(int key);
     
     /// True if the left mouse button is currently held down.
-    bool IsLeftMouseDown();
+    virtual bool IsLeftMouseDown();
     
     /// True if the middle mouse button is currently held down.
-    bool IsMiddleMouseDown();
+    virtual bool IsMiddleMouseDown();
     
     /// True if the right mouse button is currently held down.
-    bool IsRightMouseDown();
+    virtual bool IsRightMouseDown();
     
     /// Returns the current width of the client area of the window in pixels
-    int window_width();
+    virtual int window_width();
     
     /// Returns the current height of the client area of the window in pixels
-    int window_height();
+    virtual int window_height();
     
     /** Returns the current width of the framebuffer in pixels.  Note that on
      some displays (e.g., Mac Retina) the framebuffer is larger than the
      window.
      */
-    int framebuffer_width();
+    virtual int framebuffer_width();
     
     /** Returns the current height of the framebuffer in pixels.  Note that on
      some displays (e.g., Mac Retina) the framebuffer is larger than the
      window.
      */
-    int framebuffer_height();
+   virtual  int framebuffer_height();
 
     /// Returns width/height for the current shape of the window
-    float aspect_ratio();
+    virtual float aspect_ratio();
     
     
     /** Transforms a point in viewport coordinates (pixels where top left = (0,0)
@@ -329,7 +329,7 @@ public:
     
     /// Returns the z buffer value under the specified pixel.  z will be 0 at
     /// the near plane and +1 at the far plane.
-    float ReadZValueAtPixel(const Point2 &pointInPixels, unsigned int whichBuffer = GL_BACK);
+    virtual float ReadZValueAtPixel(const Point2 &pointInPixels, unsigned int whichBuffer = GL_BACK);
 
     /// Access to the underlying NanoGUI Screen object
     nanogui::Screen* screen();

--- a/tests/gui_plus_opengl/gui_plus_opengl.cc
+++ b/tests/gui_plus_opengl/gui_plus_opengl.cc
@@ -60,7 +60,7 @@ GuiPlusOpenGL::~GuiPlusOpenGL() {
     
 }
 
-void GuiPlusOpenGL::InitGraphics() {
+void GuiPlusOpenGL::InitNanoGUI() {
     nanogui::FormHelper *gui = new nanogui::FormHelper(screen());
     nanogui::ref<nanogui::Window> window = gui->addWindow(Eigen::Vector2i(10, 10), "Simulation Controls");    
     pauseBtn_ = gui->addButton("Pause", std::bind(&GuiPlusOpenGL::OnPauseBtnPressed, this));

--- a/tests/gui_plus_opengl/gui_plus_opengl.cc
+++ b/tests/gui_plus_opengl/gui_plus_opengl.cc
@@ -37,18 +37,9 @@ Point2 mpos;
 
 
 GuiPlusOpenGL::GuiPlusOpenGL() : GraphicsApp(1024,768, "Circle Simulation") {
-    nanogui::FormHelper *gui = new nanogui::FormHelper(screen());
-    nanogui::ref<nanogui::Window> window = gui->addWindow(Eigen::Vector2i(10, 10), "Simulation Controls");    
-    pauseBtn_ = gui->addButton("Pause", std::bind(&GuiPlusOpenGL::OnPauseBtnPressed, this));
-    gui->addButton("Restart", std::bind(&GuiPlusOpenGL::OnRestartBtnPressed, this));
-
-    screen()->performLayout();
-     
+    
     simTime_ = 0.0;
     paused_ = false;
-    
-    qs = new QuickShapes();
-    
     
     int i;
     i = mesh1.AddTriangle(Point3(0,0,0), Point3(1,0,0), Point3(1,1,0));
@@ -63,10 +54,21 @@ GuiPlusOpenGL::GuiPlusOpenGL() : GraphicsApp(1024,768, "Circle Simulation") {
 }
 
 
+
+
 GuiPlusOpenGL::~GuiPlusOpenGL() {
     
 }
 
+void GuiPlusOpenGL::InitGraphics() {
+    nanogui::FormHelper *gui = new nanogui::FormHelper(screen());
+    nanogui::ref<nanogui::Window> window = gui->addWindow(Eigen::Vector2i(10, 10), "Simulation Controls");    
+    pauseBtn_ = gui->addButton("Pause", std::bind(&GuiPlusOpenGL::OnPauseBtnPressed, this));
+    gui->addButton("Restart", std::bind(&GuiPlusOpenGL::OnRestartBtnPressed, this));
+
+    screen()->performLayout();
+    qs = new QuickShapes();
+}
 
 void GuiPlusOpenGL::UpdateSimulation(double dt) {
     if (!paused_) {

--- a/tests/gui_plus_opengl/gui_plus_opengl.h
+++ b/tests/gui_plus_opengl/gui_plus_opengl.h
@@ -48,6 +48,8 @@ public:
     GuiPlusOpenGL();
     ~GuiPlusOpenGL();
 
+    void InitGraphics();
+
     void UpdateSimulation(double dt);
 
 

--- a/tests/gui_plus_opengl/gui_plus_opengl.h
+++ b/tests/gui_plus_opengl/gui_plus_opengl.h
@@ -48,7 +48,7 @@ public:
     GuiPlusOpenGL();
     ~GuiPlusOpenGL();
 
-    void InitGraphics();
+    void InitNanoGUI();
 
     void UpdateSimulation(double dt);
 


### PR DESCRIPTION
The current implementation of MinGfx doesn't allow for offline testing because if we inherit from GraphicApp it will try to use a graphics context. I moved this code into an initWindow() method that is called when the Run() method is called. This way it will only try to draw graphics when the graphics loop is started. I also added a virtual method "void InitGraphics()" for initializing graphics code (this is for graphics code like buttons, sliders, nanogui stuff, etc...)

In order to maintain backwards compatibility, everything will work like it used to, however, when we are ready to force the use of InitGraphics(), I added a CMake option FORCE_INIT_GFX_NO_CONSTRUCTOR.  By default, this is set to OFF.  For the automated command line test scripts, however, it will be set to ON.  Someday, perhaps we can remove the work around completely.