### PR TITLE
Fix nanogui x64 bug and macro reuse

### DIFF
--- a/cmake/AutoBuildNanoGUI.cmake
+++ b/cmake/AutoBuildNanoGUI.cmake
@@ -35,6 +35,7 @@ macro(AutoBuild_use_package_NanoGUI YOUR_TARGET INTERFACE_PUBLIC_OR_PRIVATE)
                 ${PACKAGE_NAME}
                 .
                 -DNANOGUI_BUILD_PYTHON=OFF
+				-DCMAKE_GENERATOR_PLATFORM=${CMAKE_GENERATOR_PLATFORM}
             )
 
 

--- a/src/matrix4.cc
+++ b/src/matrix4.cc
@@ -211,26 +211,26 @@ Matrix4 Matrix4::LookAt(Point3 eye, Point3 target, Vector3 up) {
 }
 
 Matrix4 Matrix4::Perspective(float fovyInDegrees, float aspectRatio,
-                             float near, float far)
+                             float nearPlane, float farPlane)
 {
     // https://www.khronos.org/opengl/wiki/GluPerspective_code
     float ymax, xmax;
-    ymax = near * tanf(fovyInDegrees * M_PI / 360.0);
+    ymax = nearPlane * tanf(fovyInDegrees * M_PI / 360.0);
     // ymin = -ymax;
     // xmin = -ymax * aspectRatio;
     xmax = ymax * aspectRatio;
-    return Matrix4::Frustum(-xmax, xmax, -ymax, ymax, near, far);
+    return Matrix4::Frustum(-xmax, xmax, -ymax, ymax, nearPlane, farPlane);
 }
     
     
 Matrix4 Matrix4::Frustum(float left, float right,
                          float bottom, float top,
-                         float near, float far)
+                         float nearPlane, float farPlane)
 {
     return Matrix4::FromRowMajorElements(
-        2.0*near/(right-left), 0, (right+left)/(right-left), 0,
-        0, 2.0*near/(top-bottom), (top+bottom)/(top-bottom), 0,
-        0, 0, -(far+near)/(far-near), -2.0*far*near/(far-near),
+        2.0*nearPlane /(right-left), 0, (right+left)/(right-left), 0,
+        0, 2.0*nearPlane /(top-bottom), (top+bottom)/(top-bottom), 0,
+        0, 0, -(farPlane + nearPlane)/(farPlane - nearPlane), -2.0*farPlane*nearPlane /(farPlane - nearPlane),
         0, 0, -1, 0
     );
 }

--- a/src/matrix4.h
+++ b/src/matrix4.h
@@ -186,10 +186,10 @@ public:
     
     /// Returns a perspective projection matrix equivalent to the one gluPerspective
     /// creates.
-    static Matrix4 Perspective(float fovyInDegrees, float aspectRatio, float near, float far);
+    static Matrix4 Perspective(float fovyInDegrees, float aspectRatio, float nearPlane, float farPlane);
     
     /// Returns a projection matrix equivalent the one glFrustum creates
-    static Matrix4 Frustum(float left, float right, float bottom, float top, float near, float far);
+    static Matrix4 Frustum(float left, float right, float bottom, float top, float nearPlane, float farPlane);
 
     // --- Inverse, Transposeand Other General Matrix Functions ---
 


### PR DESCRIPTION
Added to nanogui cmakelists to allow it to build as the wanted syste and not default to win32. Changed variables inside of Matrix4 to not reuse macros from minwindef.h. Successfully builds on windows64 with no other changes.
fixes #14 
fixes #15 