### PR TITLE
added framerate  to GraphicsApp to limit rendering and update speed.

### DIFF
--- a/src/graphics_app.cc
+++ b/src/graphics_app.cc
@@ -202,7 +202,7 @@ void GraphicsApp::Run() {
     }
     mainloop_active = false;
     
-    refresh_thread.join()
+    refresh_thread.join();
     
     glfwTerminate();
 }

--- a/src/graphics_app.cc
+++ b/src/graphics_app.cc
@@ -169,7 +169,7 @@ void GraphicsApp::Run() {
     glfwSetTime(0.0);
     while (!glfwWindowShouldClose(window_)) {
 
-        // Poll for new user input events and call callbacks
+        // Wait for new user input events and call callbacks
         glfwWaitEvents();
 
         // Update the simulation, i.e., perform all non-graphics updates that
@@ -201,6 +201,8 @@ void GraphicsApp::Run() {
         glfwSwapBuffers(window_);
     }
     mainloop_active = false;
+    
+    refresh_thread.join()
     
     glfwTerminate();
 }

--- a/src/graphics_app.cc
+++ b/src/graphics_app.cc
@@ -5,14 +5,15 @@
  */
 
 #include "graphics_app.h"
-
+#include <thread>
+#include <chrono>
 
 namespace mingfx {
 
 
 
-GraphicsApp::GraphicsApp(int width, int height, const std::string &caption) :
-    graphicsInitialized_(false), width_(width), height_(height), caption_(caption), lastDrawT_(0.0),
+GraphicsApp::GraphicsApp(int width, int height, const std::string &caption, int frameRate) :
+    graphicsInitialized_(false), width_(width), height_(height), frameRate_(frameRate), caption_(caption), lastDrawT_(0.0),
     leftDown_(false), middleDown_(false), rightDown_(false)
 {
 }
@@ -156,6 +157,20 @@ void GraphicsApp::Run() {
         // Update the simulation, i.e., perform all non-graphics updates that
         // should happen each frame.
         double now = glfwGetTime();
+        
+        //If a framerate is specified, sleep until the minimum frame time has elapsed
+        if (frameRate_ != 0) {
+            double dt = now-lastDrawT_;
+            if (dt < 1.0 / frameRate_) {
+                //Not enough time has elapsed. Sleep to make up the difference.
+                int delay = 1000 * (1.0 / frameRate_ - dt);
+                std::this_thread::sleep_for(std::chrono::milliseconds(delay));
+
+                //Since sleeping occured, recalulate 'now' for UpdateSimulation
+                now = glfwGetTime();
+            }
+        }
+        
         UpdateSimulation(now-lastDrawT_);
         lastDrawT_ = now;
         

--- a/src/graphics_app.cc
+++ b/src/graphics_app.cc
@@ -136,7 +136,6 @@ void GraphicsApp::InitGraphicsContext() {
  }
 
 static bool mainloop_active = false;
-static std::chrono::milliseconds time(refresh);
     
 void GraphicsApp::Run() {
 
@@ -158,6 +157,7 @@ void GraphicsApp::Run() {
     int refresh = 1000 * (1.0 / frameRate_);
     refresh_thread = std::thread(
         [refresh]() {
+            std::chrono::milliseconds time(refresh);
             while (mainloop_active) {
                 std::this_thread::sleep_for(time);
                 glfwPostEmptyEvent();

--- a/src/graphics_app.h
+++ b/src/graphics_app.h
@@ -132,7 +132,7 @@ public:
      \param height The height of the client area of the window in pixels.
      \param caption The caption for the window's title bar.
      */
-    GraphicsApp(int width, int height, const std::string &caption);
+    GraphicsApp(int width, int height, const std::string &caption, int frameRate=0);
 
 
     /// The destructor will shutdown the graphics system and window
@@ -455,6 +455,7 @@ private:
     bool graphicsInitialized_;
     int width_;
     int height_;
+    int frameRate_;
     const std::string caption_;
     nanogui::Screen *screen_;
     GLFWwindow* window_;
@@ -469,4 +470,3 @@ private:
 } // end namespace
 
 #endif
-

--- a/src/graphics_app.h
+++ b/src/graphics_app.h
@@ -132,7 +132,7 @@ public:
      \param height The height of the client area of the window in pixels.
      \param caption The caption for the window's title bar.
      */
-    GraphicsApp(int width, int height, const std::string &caption, int frameRate=0);
+    GraphicsApp(int width, int height, const std::string &caption, int frameRate=60);
 
 
     /// The destructor will shutdown the graphics system and window


### PR DESCRIPTION
This pull request would add a fourth argument to GraphicsApp, frameRate. This argument defaults to 60, which sets the application to run at a nice default frameRate. If a different framerate is specified, the Run method of GraphicsApp will add a delay necessary to decrease the frameRate by using a second thread to regulate the glfwWaitEvents() function called in run. Setting the graphics app examples to run at 60fps lowered CPU usage on my system  from 98% to under 20%.