### PR TITLE
defined MinGfx specific trig functions

### DIFF
--- a/src/gfxmath.cc
+++ b/src/gfxmath.cc
@@ -16,6 +16,62 @@
 namespace mingfx {
     
 
+float GfxMath::sin(float a) {
+#ifdef WIN32
+    return std::sinf(a);
+#else
+    return std::sin(a);
+#endif
+}
+
+float GfxMath::cos(float a) {
+#ifdef WIN32
+    return std::cosf(a);
+#else
+    return std::cos(a);
+#endif
+}
+
+float GfxMath::tan(float a) {
+#ifdef WIN32
+    return std::tanf(a);
+#else
+    return std::tan(a);
+#endif
+}
+
+float GfxMath::asin(float a) {
+#ifdef WIN32
+    return std::asinf(a);
+#else
+    return std::asin(a);
+#endif
+}
+
+float GfxMath::acos(float a) {
+#ifdef WIN32
+    return std::acosf(a);
+#else
+    return std::acos(a);
+#endif
+}
+
+float GfxMath::atan(float a) {
+#ifdef WIN32
+    return std::atanf(a);
+#else
+    return std::atan(a);
+#endif
+}
+
+float GfxMath::atan2(float a, float b) {
+#ifdef WIN32
+    return std::atan2f(a, b);
+#else
+    return std::atan2(a, b);
+#endif
+}
+
 float GfxMath::Clamp(float x, float a, float b) {
     return std::min(std::max(x, a), b);
 }    

--- a/src/gfxmath.h
+++ b/src/gfxmath.h
@@ -28,6 +28,22 @@ namespace mingfx {
 class GfxMath {
 public:
 
+    /// MinGfx specific implementations of trigonometric functions included to
+    /// solve compilation issues between different platforms.
+    static float sin(float a);
+
+    static float cos(float a);
+
+    static float tan(float a);
+
+    static float asin(float a);
+
+    static float acos(float a);
+
+    static float atan(float a);
+
+    static float atan2(float a, float b);
+
     /// Returns a if x is less than a and b if x is greater than b.
     static float Clamp(float x, float a, float b);
         

--- a/src/matrix4.cc
+++ b/src/matrix4.cc
@@ -10,6 +10,8 @@
 #include <math.h>
 #include <string.h>
 
+#include "gfxmath.h"
+
 namespace mingfx {
 
     
@@ -108,8 +110,8 @@ Matrix4 Matrix4::Translation(const Vector3& v) {
 
     
 Matrix4 Matrix4::RotationX(const float radians) {
-    const float cosTheta = cos(radians);
-    const float sinTheta = sin(radians);
+    const float cosTheta = GfxMath::cos(radians);
+    const float sinTheta = GfxMath::sin(radians);
     return Matrix4::FromRowMajorElements(
         1, 0, 0, 0,
         0, cosTheta, -sinTheta, 0,
@@ -120,8 +122,8 @@ Matrix4 Matrix4::RotationX(const float radians) {
 
     
 Matrix4 Matrix4::RotationY(const float radians) {
-    const float cosTheta = cos(radians);
-    const float sinTheta = sin(radians);
+    const float cosTheta = GfxMath::cos(radians);
+    const float sinTheta = GfxMath::sin(radians);
     return Matrix4::FromRowMajorElements(
         cosTheta, 0, sinTheta, 0,
         0, 1, 0, 0,
@@ -132,8 +134,8 @@ Matrix4 Matrix4::RotationY(const float radians) {
 
     
 Matrix4 Matrix4::RotationZ(const float radians) {
-    const float cosTheta = cos(radians);
-    const float sinTheta = sin(radians);
+    const float cosTheta = GfxMath::cos(radians);
+    const float sinTheta = GfxMath::sin(radians);
     return Matrix4::FromRowMajorElements(
         cosTheta, -sinTheta, 0, 0,
         sinTheta, cosTheta, 0, 0,
@@ -146,8 +148,8 @@ Matrix4 Matrix4::RotationZ(const float radians) {
 Matrix4 Matrix4::Rotation(const Point3& p, const Vector3& v, const float a) {
     const float vZ = v[2];
     const float vX = v[0];
-    const float theta = atan2(vZ, vX);
-    const float phi   = -atan2((float)v[1], (float)sqrt(vX * vX + vZ * vZ));
+    const float theta = GfxMath::atan2(vZ, vX);
+    const float phi   = -GfxMath::atan2((float)v[1], (float)sqrt(vX * vX + vZ * vZ));
 
     const Matrix4 transToOrigin = Matrix4::Translation(-1.0*Vector3(p[0], p[1], p[2]));
     const Matrix4 A = Matrix4::RotationY(theta);

--- a/src/quaternion.cc
+++ b/src/quaternion.cc
@@ -116,12 +116,13 @@ Quaternion Quaternion::Slerp(const Quaternion &other, float alpha) const {
         return result;
     }
     
-    GfxMath::Clamp(dot, -1, 1);        // Robustness: Stay within domain of acos()
-    float theta_0 = acos(dot);        // theta_0 = angle between input vectors
-    float theta = theta_0 * alpha;    // theta = angle between v0 and result
+    GfxMath::Clamp(dot, -1, 1);         // Robustness: Stay within domain of acos()
+    float theta_0 = GfxMath::acos(dot); // theta_0 = angle between input vectors
+    float theta = theta_0 * alpha;      // theta = angle between v0 and result
     
-    float s0 = cos(theta) - dot * sin(theta) / sin(theta_0);  // == sin(theta_0 - theta) / sin(theta_0)
-    float s1 = sin(theta) / sin(theta_0);
+    float s0 = GfxMath::cos(theta) - dot
+             * GfxMath::sin(theta) / GfxMath::sin(theta_0);  // == sin(theta_0 - theta) / sin(theta_0)
+    float s1 = GfxMath::sin(theta) / GfxMath::sin(theta_0);
     
     return (s0 * v0) + (s1 * v1);
 }
@@ -177,10 +178,10 @@ Quaternion Quaternion::Conjugate() const {
 
 Quaternion Quaternion::FromAxisAngle(const Vector3 &axis, float angle) {
     // [qx, qy, qz, qw] = [sin(a/2) * vx, sin(a/2)* vy, sin(a/2) * vz, cos(a/2)]
-    float x = sin(angle/2.0) * axis[0];
-    float y = sin(angle/2.0) * axis[1];
-    float z = sin(angle/2.0) * axis[2];
-    float w = cos(angle/2.0);
+    float x = GfxMath::sin(angle/2.0) * axis[0];
+    float y = GfxMath::sin(angle/2.0) * axis[1];
+    float z = GfxMath::sin(angle/2.0) * axis[2];
+    float w = GfxMath::cos(angle/2.0);
     return Quaternion(x,y,z,w);
 }
 
@@ -200,19 +201,19 @@ Vector3 Quaternion::ToEulerAnglesZYX() const {
     // roll (x-axis rotation)
     float sinr = +2.0 * (w() * x() + y() * z());
     float cosr = +1.0 - 2.0 * (x() * x() + y() * y());
-    angles[0] = std::atan2(sinr, cosr);
+    angles[0] = GfxMath::atan2(sinr, cosr);
     
     // pitch (y-axis rotation)
     float sinp = +2.0 * (w() * y() - z() * x());
     if (std::fabs(sinp) >= 1)
         angles[1] = std::copysign(M_PI / 2, sinp); // use 90 degrees if out of range
     else
-        angles[1] = std::asin(sinp);
+        angles[1] = GfxMath::asin(sinp);
     
     // yaw (z-axis rotation)
     float siny = +2.0 * (w() * z() + x() * y());
     float cosy = +1.0 - 2.0 * (y() * y() + z() * z());
-    angles[2] = std::atan2(siny, cosy);
+    angles[2] = GfxMath::atan2(siny, cosy);
     
     return angles;
 }

--- a/src/quick_shapes.cc
+++ b/src/quick_shapes.cc
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <string>
 
+#include "gfxmath.h"
 
 namespace mingfx {
     
@@ -180,10 +181,10 @@ void QuickShapes::initCyl() {
     
     const int nslices = 20;
     for (int s=1; s<nslices+1; s++) {
-        GLfloat xlast = std::cos(-TWOPI * (float)(s-1)/(float)nslices);
-        GLfloat zlast = std::sin(-TWOPI * (float)(s-1)/(float)nslices);
-        GLfloat xnew = std::cos(-TWOPI * (float)(s)/(float)nslices);
-        GLfloat znew = std::sin(-TWOPI * (float)(s)/(float)nslices);
+        GLfloat xlast = GfxMath::cos(-TWOPI * (float)(s-1)/(float)nslices);
+        GLfloat zlast = GfxMath::sin(-TWOPI * (float)(s-1)/(float)nslices);
+        GLfloat xnew = GfxMath::cos(-TWOPI * (float)(s)/(float)nslices);
+        GLfloat znew = GfxMath::sin(-TWOPI * (float)(s)/(float)nslices);
         
         // one triangle on the top
         verts.push_back(top);
@@ -252,10 +253,10 @@ void QuickShapes::initCone() {
     
     const int nslices = 20;
     for (int s=1; s<nslices+1; s++) {
-        GLfloat xlast = std::cos(-TWOPI * (float)(s-1)/(float)nslices);
-        GLfloat zlast = std::sin(-TWOPI * (float)(s-1)/(float)nslices);
-        GLfloat xnew = std::cos(-TWOPI * (float)(s)/(float)nslices);
-        GLfloat znew = std::sin(-TWOPI * (float)(s)/(float)nslices);
+        GLfloat xlast = GfxMath::cos(-TWOPI * (float)(s-1)/(float)nslices);
+        GLfloat zlast = GfxMath::sin(-TWOPI * (float)(s-1)/(float)nslices);
+        GLfloat xnew = GfxMath::cos(-TWOPI * (float)(s)/(float)nslices);
+        GLfloat znew = GfxMath::sin(-TWOPI * (float)(s)/(float)nslices);
         
         // one triangle on the side
         // normals are a bit more complex than for other shapes...
@@ -322,26 +323,30 @@ void QuickShapes::initSph() {
     const int nslices = 40;
     const int nstacks = 40;
     for (int s=1; s<nslices+1; s++) {
-        GLfloat xlast = std::cos(-TWOPI * (float)(s-1)/(float)nslices);
-        GLfloat zlast = std::sin(-TWOPI * (float)(s-1)/(float)nslices);
-        GLfloat xnew = std::cos(-TWOPI * (float)(s)/(float)nslices);
-        GLfloat znew = std::sin(-TWOPI * (float)(s)/(float)nslices);
+        GLfloat xlast = GfxMath::cos(-TWOPI * (float)(s-1)/(float)nslices);
+        GLfloat zlast = GfxMath::sin(-TWOPI * (float)(s-1)/(float)nslices);
+        GLfloat xnew = GfxMath::cos(-TWOPI * (float)(s)/(float)nslices);
+        GLfloat znew = GfxMath::sin(-TWOPI * (float)(s)/(float)nslices);
         
         float stackstep = PI/(float)nstacks;
         
         // one triangle on the top
         verts.push_back(top);
-        verts.push_back(Vertex(std::sin(stackstep)*xlast,std::cos(stackstep),std::sin(stackstep)*zlast,
-                               std::sin(stackstep)*xlast,std::cos(stackstep),std::sin(stackstep)*zlast));
-        verts.push_back(Vertex(std::sin(stackstep)*xnew,std::cos(stackstep),std::sin(stackstep)*znew,
-                               std::sin(stackstep)*xnew,std::cos(stackstep),std::sin(stackstep)*znew));
+        verts.push_back(Vertex(GfxMath::sin(stackstep)*xlast,GfxMath::cos(stackstep),
+                               GfxMath::sin(stackstep)*zlast,
+                               GfxMath::sin(stackstep)*xlast,GfxMath::cos(stackstep),
+                               GfxMath::sin(stackstep)*zlast));
+        verts.push_back(Vertex(GfxMath::sin(stackstep)*xnew,GfxMath::cos(stackstep),
+                               GfxMath::sin(stackstep)*znew,
+                               GfxMath::sin(stackstep)*xnew,GfxMath::cos(stackstep),
+                               GfxMath::sin(stackstep)*znew));
         
         for (int t=2; t<nstacks; t++) {
-            GLfloat ylast = std::cos(PI*(float)(t-1)/(float)nstacks);
-            GLfloat ynew = std::cos(PI*(float)(t)/(float)nstacks);
+            GLfloat ylast = GfxMath::cos(PI*(float)(t-1)/(float)nstacks);
+            GLfloat ynew = GfxMath::cos(PI*(float)(t)/(float)nstacks);
             
-            GLfloat rlast = std::sin(PI * (float)(t-1)/(float)nstacks);
-            GLfloat rnew = std::sin(PI * (float)(t)/(float)nstacks);
+            GLfloat rlast = GfxMath::sin(PI * (float)(t-1)/(float)nstacks);
+            GLfloat rnew = GfxMath::sin(PI * (float)(t)/(float)nstacks);
             
             // two triangles to create a rect on the side
             verts.push_back(Vertex(rlast*xlast,ylast,rlast*zlast, rlast*xlast,ylast,rlast*zlast));
@@ -355,10 +360,14 @@ void QuickShapes::initSph() {
         
         // one triangle on the bottom
         verts.push_back(bot);
-        verts.push_back(Vertex(std::sin(stackstep)*xnew,std::cos(PI-stackstep),std::sin(stackstep)*znew,
-                               std::sin(stackstep)*xnew,std::cos(PI-stackstep),std::sin(stackstep)*znew));
-        verts.push_back(Vertex(std::sin(stackstep)*xlast,std::cos(PI-stackstep),std::sin(stackstep)*zlast,
-                               std::sin(stackstep)*xlast,std::cos(PI-stackstep),std::sin(stackstep)*zlast));
+        verts.push_back(Vertex(GfxMath::sin(stackstep)*xnew,GfxMath::cos(PI-stackstep),
+                               GfxMath::sin(stackstep)*znew,
+                               GfxMath::sin(stackstep)*xnew,GfxMath::cos(PI-stackstep),
+                               GfxMath::sin(stackstep)*znew));
+        verts.push_back(Vertex(GfxMath::sin(stackstep)*xlast,GfxMath::cos(PI-stackstep),
+                               GfxMath::sin(stackstep)*zlast,
+                               GfxMath::sin(stackstep)*xlast,GfxMath::cos(PI-stackstep),
+                               GfxMath::sin(stackstep)*zlast));
     }
     
     GLfloat *vertices = new GLfloat[3*verts.size()];

--- a/src/unicam.cc
+++ b/src/unicam.cc
@@ -191,7 +191,7 @@ void UniCam::OnDrag(const Point2 &mousePos) {
                 Vector3 v2 = (iPoint2 - boundingSphereCtr_).ToUnit();
                 
                 rotAxis_ = v1.Cross(v2).ToUnit();
-                float angle = std::acos(v1.Dot(v2));
+                float angle = GfxMath::acos(v1.Dot(v2));
 
                 if (std::isfinite(angle)) {
                     Matrix4 R = Matrix4::Rotation(boundingSphereCtr_, rotAxis_, angle);


### PR DESCRIPTION
To avoid complications encountered with different compilers and
language standards, the float returning trigonometric functions
have been added to the MinGfx::GfxMath class to contain their
intended behavior. Compiler directives are used to switch between
which version of the function to call based on the platform or
compiler that is being used.