### PR TITLE
fix vector inequality

### DIFF
--- a/src/vector2.cc
+++ b/src/vector2.cc
@@ -50,7 +50,7 @@ bool Vector2::operator==(const Vector2& other) const {
 }
 
 bool Vector2::operator!=(const Vector2& other) const {
-    return (fabs(other[0] - v[0]) >= MINGFX_MATH_EPSILON &&
+    return (fabs(other[0] - v[0]) >= MINGFX_MATH_EPSILON ||
             fabs(other[1] - v[1]) >= MINGFX_MATH_EPSILON);
 }
 

--- a/src/vector3.cc
+++ b/src/vector3.cc
@@ -57,8 +57,8 @@ bool Vector3::operator==(const Vector3& other) const {
 }
   
 bool Vector3::operator!=(const Vector3& other) const {
-    return (fabs(other[0] - v[0]) >= MINGFX_MATH_EPSILON &&
-            fabs(other[1] - v[1]) >= MINGFX_MATH_EPSILON &&
+    return (fabs(other[0] - v[0]) >= MINGFX_MATH_EPSILON ||
+            fabs(other[1] - v[1]) >= MINGFX_MATH_EPSILON ||
             fabs(other[2] - v[2]) >= MINGFX_MATH_EPSILON);
 }
 


### PR DESCRIPTION
Vector inequality method used incorrect logic with AND rather
than OR.