### PR TITLE
Fix linux compile issue due to cosf and sinf usage.

### DIFF
--- a/tests/gui_plus_opengl/gui_plus_opengl.cc
+++ b/tests/gui_plus_opengl/gui_plus_opengl.cc
@@ -216,14 +216,14 @@ void GuiPlusOpenGL::DrawUsingNanoVG(NVGcontext *ctx) {
     // example of drawing some circles
     
     nvgBeginPath(ctx);
-    nvgCircle(ctx, 512.0f+50.0f*std::cos((float)simTime_), 350.0f+200.0f*std::sin((float)simTime_), 50.0f);
+    nvgCircle(ctx, 512.0f+50.0f*GfxMath::cos((float)simTime_), 350.0f+200.0f*GfxMath::sin((float)simTime_), 50.0f);
     nvgFillColor(ctx, nvgRGBA(100,100,255,200));
     nvgFill(ctx);
     nvgStrokeColor(ctx, nvgRGBA(0,0,0,255));
     nvgStroke(ctx);
 
     nvgBeginPath(ctx);
-    nvgCircle(ctx, 512.0f+200.0f*std::cos((float)simTime_), 350.0f+50.0f*std::sin((float)simTime_), 50.0f);
+    nvgCircle(ctx, 512.0f+200.0f*GfxMath::cos((float)simTime_), 350.0f+50.0f*GfxMath::sin((float)simTime_), 50.0f);
     nvgFillColor(ctx, nvgRGBA(255,100,100,200));
     nvgFill(ctx);
     nvgStrokeColor(ctx, nvgRGBA(0,0,0,255));


### PR DESCRIPTION
This fix is in reference to #21 which explains the errors experienced without these changes. The change uses C++'s overloaded `std::cos` and `std::sin` which can take `float` as an argument and return it. See this [cpp reference page](https://en.cppreference.com/w/cpp/numeric/math/cos) for the overloaded function. The reason `cosf` and `sinf` do not work on Linux is due to this [bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=79700) I believe.

Please let me know if I need to follow particular guidelines for PRs in this repo. For now, I have posted some evidence of it operating on my setup (see #21) below.

### Evidence
Both `mingfx-test-blank-window` and `mingfx-test-gui-plus-opengl`  were run to test these changes.**Note:** I did have to add the `lib` path to my `LD_LIBRARY_PATH` in order to run the tests (it said `libnanogui.so` could not be found). I am not sure at this point what causes that issue.

#### Blank Window Test
After building, the `mingfx-test-blank-window` program was run and the output can be seen below.

![mingfx_pr_blank_window_test](https://user-images.githubusercontent.com/28640027/134983864-63fc708b-2449-4985-85f1-c993f0ae8676.png)

#### GUI + OpenGL Test
Similarly, after building, the `mingfx-test-gui-plus-opengl` program was run and the output can be seen below. I was also able to pause, play, move the button box, translate, and zoom in and out successfully.

![mingfx_pr_opengl_test](https://user-images.githubusercontent.com/28640027/134983880-f5ae6b31-09ac-40b6-9d23-f932048c7ec4.png)



Close #21